### PR TITLE
docs: add directory agent specifications

### DIFF
--- a/app/AGENT.md
+++ b/app/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+Contains the Kirigami-based GUI application. Hosts the QML interface, icons, and C++ sources that communicate with the daemon.
+
+## Sibling directories
+- **qml/** – QML components for the overlay, dashboard, and settings.
+- **icons/** – SVG/PNG assets embedded into the application.
+- **src/** – C++20 sources implementing application logic, API access, and settings persistence.
+
+## Integration
+The GUI talks to the daemon's HTTP server over `ApiClient` and reflects configuration changes stored in the daemon. Resources are embedded through `app.qrc` and built with Qt6/KF6 via the app's CMakeLists.txt.

--- a/app/icons/AGENT.md
+++ b/app/icons/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+Contains icon assets (SVG/PNG) bundled into the application.
+
+## Interaction
+Icons are referenced from QML and embedded via `app.qrc`. No code resides here.

--- a/app/qml/AGENT.md
+++ b/app/qml/AGENT.md
@@ -1,0 +1,10 @@
+# AGENT.md
+
+## Purpose
+QML files defining all visual components: Main window, overlay, dashboard pages, and settings dialogs.
+
+## Interaction
+Components bind to C++ singletons (SettingsStore, ApiClient, OverlayController) via `qmlRegisterSingletonInstance`. Signals and slots propagate user actions to the daemon and render responses.
+
+## Notes
+Keep QML accessible and Wayland compliant. Use Kirigami style components and avoid blocking operations.

--- a/app/src/AGENT.md
+++ b/app/src/AGENT.md
@@ -1,0 +1,14 @@
+# AGENT.md
+
+## Purpose
+C++20 sources for the GUI application including entry point, overlay controller, API client, settings store, and metrics view.
+
+## Key files
+- **main.cpp** – sets up application, registers singletons, loads QML.
+- **overlay_controller.cpp** – toggles overlay, handles user input.
+- **api_client.cpp** – asynchronous HTTP client to the daemon.
+- **settings_store.cpp** – persists user preferences and notifies daemon.
+- **metrics_view.cpp** – displays daemon metrics.
+
+## Integration
+Links against Qt6 and KF6 modules. Communicates with daemon endpoints defined in `daemon/openapi.yaml`.

--- a/cmake/AGENT.md
+++ b/cmake/AGENT.md
@@ -1,0 +1,11 @@
+# AGENT.md
+
+## Purpose
+CMake helper modules and toolchain files used by both app and daemon builds.
+
+## Sibling files
+- **toolchains.cmake** – selects compilers and Qt paths.
+- **warnings.cmake** – enforces warnings-as-errors and common flags.
+
+## Integration
+Included from top-level and subproject CMakeLists to keep build settings consistent.

--- a/daemon/AGENT.md
+++ b/daemon/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+Headless daemon providing OCR capture, summarisation, storage, and HTTP APIs.
+
+## Sibling items
+- **src/** – C++20 sources for queues, HTTP server, storage, and integrations.
+- **openapi.yaml** – REST contract consumed by the GUI and scripts.
+- **CMakeLists.txt** – build rules linking QtCore, NVML, SQLite, PipeWire, and optional ONNX runtime.
+
+## Integration
+Listens only on localhost. Interacts with `third_party/llama.cpp` for language model inference and stores data under SQLite schemas in `daemon/src/store/`.

--- a/daemon/src/AGENT.md
+++ b/daemon/src/AGENT.md
@@ -1,0 +1,16 @@
+# AGENT.md
+
+## Purpose
+Core daemon sources implementing capture pipelines, task queue, GPU guard, HTTP server, storage, logging, metrics, and config handling.
+
+## Key modules
+- **main.cpp** – initialises subsystems and event loop.
+- **http_server.cpp** – exposes REST and metrics endpoints.
+- **queue.cpp** – priority job scheduler coordinating with GpuGuard.
+- **gpu_guard.cpp** – monitors NVML utilisation and throttles queue.
+- **ocr/** – OCR engines and capture helpers.
+- **store/** – SQLite persistence layer.
+- **exporters/** – data export formats.
+
+## Integration
+Uses NVML, PipeWire, ONNX Runtime (optional) and SQLite. Communicates with llama.cpp via `llama_client.cpp` and serves the GUI through localhost HTTP.

--- a/daemon/src/capture/AGENT.md
+++ b/daemon/src/capture/AGENT.md
@@ -1,0 +1,11 @@
+# AGENT.md
+
+## Purpose
+Capture utilities for obtaining screen frames and detecting changes before OCR.
+
+## Key files
+- **screencast_portal.cpp** – Wayland capture via xdg-desktop-portal and PipeWire.
+- **frame_diff.cpp** – computes changed regions to minimise OCR work.
+
+## Integration
+Feeds images into the OCR engines under `ocr/` and respects user privacy by capturing only active windows.

--- a/daemon/src/enrich/AGENT.md
+++ b/daemon/src/enrich/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+Optional enrichment modules that augment OCR text using external APIs.
+
+## Key files
+- **enrich_none.cpp** – pass-through implementation.
+- **enrich_openai.cpp** – calls OpenAI with API key #1.
+- **enrich_secondary.cpp** – secondary provider for metrics or alternate summaries.
+
+## Integration
+Modules are selected via configuration and run after OCR before storage or export. They must respect rate limits and never block the main thread.

--- a/daemon/src/exporters/AGENT.md
+++ b/daemon/src/exporters/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+Implement export formats for stored notes.
+
+## Key files
+- **export_raw.cpp** – streams raw text.
+- **export_json.cpp** – emits structured JSON records.
+- **export_csv.cpp** – outputs CSV for spreadsheets.
+
+## Integration
+Exporters read from `store/sqlite_store.cpp` using prepared statements and support chunked streaming over HTTP.

--- a/daemon/src/ocr/AGENT.md
+++ b/daemon/src/ocr/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+OCR engines translating captured frames into text.
+
+## Key files
+- **ocr_engine.h** – factory interface.
+- **ocr_tesseract.cpp** – CPU path using Tesseract.
+- **ocr_paddle.cpp** – GPU-accelerated path using ONNX Runtime and PaddleOCR.
+
+## Integration
+Receives images from `capture/`, outputs text to enrichment modules and storage. GPU path respects NVML limits controlled by `gpu_guard.cpp`.

--- a/daemon/src/store/AGENT.md
+++ b/daemon/src/store/AGENT.md
@@ -1,0 +1,11 @@
+# AGENT.md
+
+## Purpose
+Persistent storage using SQLite with WAL and FTS5.
+
+## Key files
+- **sqlite_store.cpp** – database wrapper using prepared statements.
+- **schema.sql** – versioned schema with triggers.
+
+## Integration
+Stores notes, configurations, and metadata consumed by exporters and API handlers. Accessed via thread-safe connections.

--- a/daemon/src/windows/AGENT.md
+++ b/daemon/src/windows/AGENT.md
@@ -1,0 +1,10 @@
+# AGENT.md
+
+## Purpose
+Platform-specific helpers for window metadata.
+
+## Key file
+- **kwin_watcher.cpp** – monitors active window via KWin DBus and supplies metadata to capture and logging systems.
+
+## Integration
+Used by capture and logging to associate OCR text with originating windows while respecting Wayland security boundaries.

--- a/models/AGENT.md
+++ b/models/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+Stores GGUF model weights for llama.cpp. Files are not committed but downloaded via scripts.
+
+## Integration
+`daemon` and `run-dev.sh` reference paths here when launching the llama server.

--- a/packaging/AGENT.md
+++ b/packaging/AGENT.md
@@ -1,0 +1,11 @@
+# AGENT.md
+
+## Purpose
+Packaging artifacts such as systemd units, polkit policies, and desktop entries.
+
+## Sibling files
+- **systemd/** – user services for the daemon and model server.
+- **polkit/** – policies granting screen-cast and device access.
+
+## Integration
+Installed by distribution packages or `scripts/setup-arch.sh` to integrate VibeNote with the host system.

--- a/packaging/polkit/AGENT.md
+++ b/packaging/polkit/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+Polkit policy files granting the daemon permission to access screen-cast and system resources.
+
+## Integration
+Installed by setup scripts to `/usr/share/polkit-1/actions/` so the daemon can request PipeWire capture without root.

--- a/packaging/systemd/AGENT.md
+++ b/packaging/systemd/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+Systemd user service units for launching the daemon and optional model server.
+
+## Integration
+Installed into `~/.config/systemd/user` by packaging or setup scripts and reference binaries built under `app` and `daemon`.

--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -1,0 +1,14 @@
+# AGENT.md
+
+## Purpose
+Shell utilities for development, setup, benchmarking, and exporting notes.
+
+## Key scripts
+- **setup-arch.sh** – installs dependencies, downloads models, deploys services.
+- **build.sh** – configures and builds the project.
+- **run-dev.sh** – launches llama server, daemon, and GUI for development.
+- **bench.sh** – benchmarks summarisation and GPU usage.
+- **export-examples.sh** – demonstrates export API outputs.
+
+## Integration
+Scripts invoke the compiled binaries in `app` and `daemon` and rely on `third_party/llama.cpp` and `models/` when applicable.

--- a/tests/AGENT.md
+++ b/tests/AGENT.md
@@ -1,0 +1,12 @@
+# AGENT.md
+
+## Purpose
+Test suite covering daemon logic, GUI components, and end-to-end flows.
+
+## Subdirectories
+- **daemon/** – unit tests for queue, GPU guard, OCR, and HTTP handlers.
+- **app/** – QtTest-based tests for overlay controller and API client.
+- **integration/** – starts real components to test summarisation and export paths.
+
+## Integration
+Tests use mocks for NVML, PipeWire, and external APIs. Run with CTest after building.

--- a/tests/app/AGENT.md
+++ b/tests/app/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+QtTest cases for GUI logic including overlay controller, settings store, and API client.
+
+## Integration
+Uses QSignalSpy and mock HTTP servers to validate interactions with the daemon without network access.

--- a/tests/daemon/AGENT.md
+++ b/tests/daemon/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+GoogleTest or Catch2 unit tests for daemon subsystems: queue scheduling, GPU guard behaviour, OCR pipelines, HTTP handlers, and storage.
+
+## Integration
+Mocks NVML, PipeWire, and database to test logic deterministically. Linked against daemon objects but not the GUI.

--- a/tests/integration/AGENT.md
+++ b/tests/integration/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+End-to-end tests that launch the daemon, optional llama server, and exercise public HTTP endpoints.
+
+## Integration
+Validate watch mode, summarisation, and export flows through real HTTP calls. Use temporary directories and mock models for reproducibility.

--- a/third_party/AGENT.md
+++ b/third_party/AGENT.md
@@ -1,0 +1,7 @@
+# AGENT.md
+
+## Purpose
+External dependencies vendored or as submodules, such as llama.cpp.
+
+## Integration
+Built by scripts and linked by daemon or app as required. Keep versions pinned and review licences before inclusion.


### PR DESCRIPTION
## Summary
- add AGENT.md guides for app, daemon, scripts, tests, and packaging directories
- document interactions between components and external tooling

## Testing
- `find . -name AGENT.md | sort`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_689cc85fa5bc832ab506fb15dcf1cffc