### PR TITLE
fix(cmake): allow overriding Qt6/KF6 paths via environment

### DIFF
--- a/cmake/toolchains.cmake
+++ b/cmake/toolchains.cmake
@@ -21,8 +21,24 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pthread")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed")
 
-# System library and Qt6 locations for Arch Linux
-list(PREPEND CMAKE_PREFIX_PATH "/usr" "/usr/lib/cmake/Qt6")
+# System library, Qt6 and KF6 locations for Arch Linux
+# Allow overriding the Qt and KDE Frameworks installation paths via environment
+# variables so IDEs like KDevelop can discover them when installed outside the
+# default system prefix. Qt's CMake files are typically under
+# <prefix>/lib/cmake/Qt6, KDE Frameworks under <prefix>/lib/cmake/KF6.
+if(DEFINED ENV{Qt6_DIR})
+  list(PREPEND CMAKE_PREFIX_PATH "$ENV{Qt6_DIR}")
+elseif(DEFINED ENV{QT6_DIR})
+  list(PREPEND CMAKE_PREFIX_PATH "$ENV{QT6_DIR}")
+endif()
+if(DEFINED ENV{KF6_DIR})
+  list(PREPEND CMAKE_PREFIX_PATH "$ENV{KF6_DIR}")
+elseif(DEFINED ENV{KF_DIR})
+  list(PREPEND CMAKE_PREFIX_PATH "$ENV{KF_DIR}")
+endif()
+
+# Standard search prefixes for Arch Linux
+list(APPEND CMAKE_PREFIX_PATH "/usr" "/usr/lib/qt6" "/usr/lib/cmake/Qt6" "/usr/lib/cmake/KF6")
 
 # Optional CUDA configuration for PaddleOCR acceleration
 if(ENABLE_PADDLE_OCR)


### PR DESCRIPTION
## Summary
- allow setting custom Qt6 install directory via `Qt6_DIR`/`QT6_DIR`
- allow setting custom KDE Frameworks 6 install directory via `KF6_DIR`/`KF_DIR`
- document standard Arch prefixes for Qt6 and KF6

## Testing
- `cmake -S . -B build` *(fails: Qt6Config.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7b4590c832ab806539bc8cab42d